### PR TITLE
Add support for Objective-C bridging

### DIFF
--- a/ValueCoding/ValueCoding.swift
+++ b/ValueCoding/ValueCoding.swift
@@ -72,6 +72,32 @@ extension CodingType where ValueType: ValueCoding, ValueType.Coder == Self {
     }
 }
 
+/**
+ Objective-C bridging support. Allows for use of value types in `NSArray` and company.
+ */
+extension ValueCoding where Coder: NSCoding, Coder.ValueType == Self {
+    static func _isBridgedToObjectiveC() -> Bool {
+        return true
+    }
+    
+    static func _getObjectiveCType() -> Any.Type {
+        return Coder.self
+    }
+    
+    static func _forceBridgeFromObjectiveC(source: Coder, inout result: Self?) {
+        result = source.value
+    }
+    
+    static func _conditionallyBridgeFromObjectiveC(source: Coder, inout result: Self?) -> Bool {
+        result = source.value
+        return true
+    }
+    
+    func _bridgeToObjectiveC() -> Coder {
+        return encoded
+    }
+}
+
 extension SequenceType where
     Generator.Element: CodingType {
 


### PR DESCRIPTION
You still have to opt in to get the bridging support with `extension Foo: _ObjectiveCBridgeable { }` but this supplies the implementation of that protocol for ValueCoding types.

I wasn't really sure if you'd even want this, but it's an extension I wrote for use in my project and thought I'd share it, just in case. Feel free to close the PR if you don't want it in there :)